### PR TITLE
eth-utils 1b2 & latest template updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,65 @@
+version: 2.0
+
+# heavily inspired by https://raw.githubusercontent.com/pinax/pinax-wiki/6bd2a99ab6f702e300d708532a6d1d9aa638b9f8/.circleci/config.yml
+
+common: &common
+  working_directory: ~/repo
+  steps:
+    - checkout
+    - restore_cache:
+        keys:
+          - cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+    - run:
+        name: install dependencies
+        command: pip install --user tox
+    - run:
+        name: run tox
+        command: ~/.local/bin/tox
+    - save_cache:
+        paths:
+          - .tox
+          - ~/.cache/pip
+          - ~/.local
+          - ./eggs
+        key: cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+
+jobs:
+  doctest:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: doctest
+  lint:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: lint
+  py35-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: py35-core
+  py36-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-core
+  pypy3-core:
+    <<: *common
+    docker:
+      - image: pypy
+        environment:
+          TOXENV: pypy3-core
+workflows:
+  version: 2
+  test:
+    jobs:
+      - doctest
+      - lint
+      - py35-core
+      - py36-core
+      - pypy3-core

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ matrix:
     #
     # Python 3.5 testing
     #
+    # doctest
+    - python: "3.5"
+      env: TOX_POSARGS="-e doctest"
     # lint
     - python: "3.5"
       env: TOX_POSARGS="-e lint"
@@ -18,6 +21,12 @@ matrix:
     # core
     - python: "3.6"
       env: TOX_POSARGS="-e py36-core"
+    #
+    # pypy3 testing
+    #
+    # core
+    - python: "pypy3.5"
+      env: TOX_POSARGS="-e pypy3-core"
 cache:
   - pip: true
 install:

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ build-docs:
 	sphinx-apidoc -o docs/ . setup.py "*conftest*"
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
+	$(MAKE) -C docs doctest
 
 docs: build-docs
 	open docs/_build/html/index.html

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # HexBytes
 
 [![Join the chat at https://gitter.im/ethereum/web3.py](https://badges.gitter.im/ethereum/web3.py.svg)](https://gitter.im/ethereum/web3.py?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-
 [![Build Status](https://travis-ci.org/carver/hexbytes.png)](https://travis-ci.org/carver/hexbytes)
+[![PyPI version](https://badge.fury.io/py/hexbytes.svg)](https://badge.fury.io/py/hexbytes)
+[![Python versions](https://img.shields.io/pypi/pyversions/hexbytes.svg)](https://pypi.python.org/pypi/hexbytes)
+[![Docs build](https://readthedocs.org/projects/hexbytes/badge/?version=latest)](http://hexbytes.readthedocs.io/en/latest/?badge=latest)
    
 
 Python `bytes` subclass that decodes hex, with a readable console output
 
 * Python 3.5+ support
 
-Read more in the [documentation on ReadTheDocs](http://hexbytes.readthedocs.io/). [View the change log on Github](docs/releases.rst).
+Read more in the [documentation on ReadTheDocs](http://hexbytes.readthedocs.io/). [View the change log](http://hexbytes.readthedocs.io/en/latest/releases.html).
 
 ## Quickstart
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,11 @@ with open (os.path.join(DIR, '../setup.py'), 'r') as f:
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx']
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
+    'sphinx.ext.intersphinx',
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -271,3 +275,14 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3.5', None),
 }
+
+# -- Doctest configuration ----------------------------------------
+
+import doctest
+
+doctest_default_flags = (0
+    | doctest.DONT_ACCEPT_TRUE_FOR_1
+    | doctest.ELLIPSIS
+    | doctest.IGNORE_EXCEPTION_DETAIL
+    | doctest.NORMALIZE_WHITESPACE
+)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,4 +18,3 @@ Indices and tables
 
 * :ref:`genindex`
 * :ref:`modindex`
-* :ref:`search`

--- a/fill_template_vars.sh
+++ b/fill_template_vars.sh
@@ -38,3 +38,6 @@ sed -i "s/<SHORT_DESCRIPTION>/$SHORT_DESCRIPTION/g" $TEMPLATE_FILES
 
 mkdir $MODULE_NAME
 touch $MODULE_NAME/__init__.py
+
+# template filler is no longer needed, delete it
+rm "$0"

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ extras_require={
         "pytest==3.3.2",
         "tox>=2.9.1,<3",
         "hypothesis>=3.44.24,<4",
+        "eth-hash[pycryptodome]",
     ],
     'lint': [
         "flake8==3.4.1",
@@ -46,7 +47,7 @@ setup(
     url='https://github.com/ethereum/hexbytes',
     include_package_data=True,
     install_requires=[
-        'eth-utils==1.0.0-beta.1',
+        'eth-utils>=1.0.0-beta.2,<2.0.0',
     ],
     setup_requires=['setuptools-markdown'],
     extras_require=extras_require,

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,9 @@ extras_require={
     'dev': [
         "bumpversion>=0.5.3,<1",
         "pytest-xdist",
+        "pytest-watch>=4.1.0,<5",
         "wheel",
+        "ipython",
     ],
 }
 
@@ -61,5 +63,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: Implementation :: PyPy',
     ],
 )

--- a/tests/core/test_import.py
+++ b/tests/core/test_import.py
@@ -1,0 +1,4 @@
+
+
+def test_import():
+    import hexbytes  # noqa: F401

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist=
-    py{35,36}-core
+    py{35,36,py3}-core
     lint
+    doctest
 
 [isort]
 combine_as_imports=True
@@ -23,10 +24,16 @@ ignore=
 usedevelop=True
 commands=
     core: py.test {posargs:tests}
+    doctest: make -C {toxinidir}/docs doctest
 basepython =
+    doctest: python
     py35: python3.5
     py36: python3.6
-extras=test
+    pypy3: pypy3
+extras=
+    test
+    doctest: doc
+whitelist_externals=make
 
 [testenv:lint]
 basepython=python


### PR DESCRIPTION
## What was wrong?

eth-utils v1b2 is cranky, and requires special handling and love. (It's better, and worth it, really)

## How was it fixed?

Specify eth-hash backend for testing, require eth-utils v1b2 or higher. Get pypy3 support for free!

Plus, merged in a bunch of project template stuff.
